### PR TITLE
Add person with additional info from dbpedia

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,3 +14,9 @@
  *= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
  *= require_self
  */
+
+.linked-data-alt-authority, .linked-data-additional_uris {
+    font-size: .8em;
+    color: darkgray;
+    margin-top: 7px;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -90,11 +90,13 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("title", :stored_searchable), label: "Title"
     config.add_show_field solr_name("description", :stored_searchable), label: "Description"
 
-    config.add_show_field solr_name("oclc_organization", :stored_searchable), label: "Oclc Organization"
-    config.add_show_field solr_name("agrovoc_keyword", :stored_searchable), label: "Agrovoc Keyword (en)"
-    config.add_show_field solr_name("agrovoc_keyword_uri", :stored_searchable), label: "Agrovoc Keyword URI (en)"
-    config.add_show_field solr_name("agrovoc_keyword_fr", :stored_searchable), label: "Agrovoc Keyword (fr)"
-    config.add_show_field solr_name("agrovoc_keyword_fr_uri", :stored_searchable), label: "Agrovoc Keyword URI (fr)"
+    # config.add_show_field solr_name("oclc_organization", :stored_searchable), label: "Oclc Organization"
+    # config.add_show_field solr_name("oclc_person", :stored_searchable), label: "Oclc Person"
+    # config.add_show_field solr_name("oclc_person_uri", :stored_searchable), label: "Oclc Person URI"
+    # config.add_show_field solr_name("agrovoc_keyword", :stored_searchable), label: "Agrovoc Keyword (en)"
+    # config.add_show_field solr_name("agrovoc_keyword_uri", :stored_searchable), label: "Agrovoc Keyword URI (en)"
+    # config.add_show_field solr_name("agrovoc_keyword_fr", :stored_searchable), label: "Agrovoc Keyword (fr)"
+    # config.add_show_field solr_name("agrovoc_keyword_fr_uri", :stored_searchable), label: "Agrovoc Keyword URI (fr)"
 
     config.add_show_field solr_name("keyword", :stored_searchable), label: "Keyword"
     config.add_show_field solr_name("subject", :stored_searchable), label: "Subject"

--- a/app/forms/hyrax/demo_work_form.rb
+++ b/app/forms/hyrax/demo_work_form.rb
@@ -3,12 +3,12 @@
 module Hyrax
   class DemoWorkForm < Hyrax::Forms::WorkForm
     self.model_class = ::DemoWork
-    self.terms += [:resource_type, :oclc_organization, :oclc_organization_uri, :agrovoc_keyword, :agrovoc_keyword_uri, :agrovoc_keyword_fr, :agrovoc_keyword_fr_uri, :loc_name, :loc_name_uri]
-    self.required_fields += [:oclc_organization, :agrovoc_keyword, :agrovoc_keyword_fr]
+    self.terms += [:resource_type, :oclc_organization, :oclc_organization_uri, :oclc_person, :oclc_person_uri, :agrovoc_keyword, :agrovoc_keyword_uri, :agrovoc_keyword_fr, :agrovoc_keyword_fr_uri, :loc_name, :loc_name_uri]
+    self.required_fields += [:oclc_organization, :oclc_person, :agrovoc_keyword, :agrovoc_keyword_fr]
 
     def primary_terms
       # Prevent URIs from being displayed by hydra-editor.  They are displayed paired with their corresponding label fields.
-      required_fields - [:oclc_organization_uri, :agrovoc_keyword_uri, :agrovoc_keyword_fr_uri, :loc_name_uri]
+      required_fields - [:oclc_organization_uri, :oclc_person_uri, :agrovoc_keyword_uri, :agrovoc_keyword_fr_uri, :loc_name_uri]
     end
   end
 end

--- a/app/models/demo_work.rb
+++ b/app/models/demo_work.rb
@@ -14,6 +14,13 @@ class DemoWork < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :oclc_person_uri, predicate: ::RDF::URI.new('http://www.example.org/ns#oclc_person'), multiple: true do |index|
+    index.as :stored_searchable
+  end
+  property :oclc_person, predicate: ::RDF::URI.new('http://www.example.org/ns#oclc_person_label'), multiple: true do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # TODO: URI probably doesn't need to be stored_searchable, but I couldn't get it to show up on the show page for the work with out this
   property :agrovoc_keyword_uri, predicate: ::RDF::URI.new('http://www.example.org/ns#agrovoc_keyword'), multiple: true do |index|
     index.as :stored_searchable

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,6 +34,14 @@ class SolrDocument
     self[Solrizer.solr_name('oclc_organization_uri')]
   end
 
+  def oclc_person
+    self[Solrizer.solr_name('oclc_person')]
+  end
+
+  def oclc_person_uri
+    self[Solrizer.solr_name('oclc_person_uri')]
+  end
+
   def agrovoc_keyword
     self[Solrizer.solr_name('agrovoc_keyword')]
   end

--- a/app/presenters/demo_work_presenter.rb
+++ b/app/presenters/demo_work_presenter.rb
@@ -1,4 +1,4 @@
 # app/presenters/demo_work_presenter.rb
 class DemoWorkPresenter < Hyrax::WorkShowPresenter
-  delegate :oclc_organization, :oclc_organization_uri, :agrovoc_keyword, :agrovoc_keyword_uri, :agrovoc_keyword_fr, :agrovoc_keyword_fr_uri, to: :solr_document
+  delegate :oclc_organization, :oclc_organization_uri, :oclc_person, :oclc_person_uri, :agrovoc_keyword, :agrovoc_keyword_uri, :agrovoc_keyword_fr, :agrovoc_keyword_fr_uri, to: :solr_document
 end

--- a/app/renderers/hyrax/renderers/faceted_linked_data_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/faceted_linked_data_attribute_renderer.rb
@@ -1,0 +1,74 @@
+module Hyrax
+  module Renderers
+    class FacetedLinkedDataAttributeRenderer < Hyrax::Renderers::ExternalLinkAttributeRenderer
+      def attribute_value_to_html(value)
+        uri_link = super
+
+        lda = Qa::Authorities::LinkedData::GenericAuthority.new(:AGROVOC)
+        ld_results = lda.find agrovoc_id value
+        return uri_link if ld_results.nil? || !ld_results.kind_of?(Hash) || ld_results.empty?
+
+        label_link = faceted_attribute_value_to_html(ld_results[:label])
+        ret = label_link
+        ret.concat("  ")
+        ret.concat(uri_link)
+
+        narrower_uris = ld_results[:narrower]
+        broader_uris = ld_results[:broader]
+        sameas_uris = ld_results[:sameas]
+
+        ret.safe_concat "<div class='linked-data-additional_uris'>"
+        # ret.safe_concat render_uris("uri", [value])
+        ret.safe_concat render_uris("narrower", narrower_uris, lda)
+        ret.safe_concat render_uris("broader", broader_uris, lda)
+        ret.safe_concat render_uris("sameas", sameas_uris)
+        ret.safe_concat "</div>"
+        ret
+      end
+
+      private
+        def faceted_attribute_value_to_html label
+          label_li_value(label.first)
+        end
+
+        def agrovoc_id uri
+          uri.split("/").last
+        end
+
+        def render_uris label, uris, lda=nil
+          return "" if uris.nil? || !uris.kind_of?(Array) || uris == [""]
+          link_html = "<p>"
+          uris.each do |uri|
+            link_html.concat "  #{label}: #{uri_label(lda, uri)}  <span class='glyphicon glyphicon-new-window'></span>&nbsp\;#{auto_link(uri)}</br>"
+          end
+          link_html.concat "</p>"
+        end
+
+        def uri_label lda, uri
+          return if lda.nil? || uri.nil?
+          ld_results = lda.find agrovoc_id uri
+          label = ld_results[:label].first
+          return " #{label_li_value(label)}  " unless label.nil? || !label.length.positive?
+          ""
+        end
+
+        def label_li_value(value)
+          link_to(ERB::Util.h(value), search_path(value))
+        end
+
+        def search_path(value)
+          Rails.application.routes.url_helpers.search_catalog_path(:"f[#{search_field}][]" => ERB::Util.h(value))
+        end
+
+        def search_field
+          ERB::Util.h(Solrizer.solr_name(options.fetch(:search_field, label_field_sym), :facetable, type: :string))
+        end
+
+        def label_field_sym
+          label_field = field.to_s
+          label_field.slice!("_uri")
+          label_field.to_sym
+        end
+    end
+  end
+end

--- a/app/renderers/hyrax/renderers/faceted_plus_dbpedia_data_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/faceted_plus_dbpedia_data_attribute_renderer.rb
@@ -1,0 +1,27 @@
+module Hyrax
+  module Renderers
+    class FacetedPlusDbpediaDataAttributeRenderer < Hyrax::Renderers::FacetedAttributeRenderer
+      def attribute_value_to_html(value)
+        ret = super
+        parts = value.split(', ')
+        name = "#{parts.second}+#{parts.first}"
+        lda = Qa::Authorities::LinkedData::GenericAuthority.new(:DBPEDIA)
+        ld_results = lda.find name
+        return ret if ld_results.nil? || !ld_results.kind_of?(Hash) || ld_results.empty?
+
+        dbpedia_uri = ld_results[:uri]
+        birthdate = ld_results['predicates']['http://dbpedia.org/ontology/birthDate'].first
+        deathdate = ld_results['predicates']['http://dbpedia.org/property/deathDate'].first
+        abstract =  ld_results['predicates']['http://dbpedia.org/ontology/abstract'].first
+
+        ret.safe_concat "<div class='linked-data-alt-authority'>"
+        ret.safe_concat "  (<i>source: <span class='glyphicon glyphicon-new-window'></span>&nbsp;#{auto_link(dbpedia_uri)}</i> )"
+        ret.safe_concat "  <p class='data birthdate'>Birth: #{birthdate}</p>"
+        ret.safe_concat "  <p class='data deathdate'>Death: #{deathdate}</p>"
+        ret.safe_concat "  <p class='data abstract'>#{abstract}</p>"
+        ret.safe_concat "</div>"
+        ret
+      end
+    end
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,8 +1,9 @@
 <%= presenter.attribute_to_html(:creator, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:oclc_organization, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:agrovoc_keyword, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:agrovoc_keyword_uri, render_as: :external_link) %>
+<%= presenter.attribute_to_html(:oclc_person, render_as: :faceted_plus_dbpedia_data) %>
+<%= presenter.attribute_to_html(:oclc_person_uri, render_as: :external_link) %>
+<%= presenter.attribute_to_html(:agrovoc_keyword_uri, render_as: :faceted_linked_data, label: 'Agrovoc Keyword') %>
 <%= presenter.attribute_to_html(:agrovoc_keyword_fr, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:agrovoc_keyword_fr_uri, render_as: :external_link) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>

--- a/app/views/records/edit_fields/_oclc_person.html.erb
+++ b/app/views/records/edit_fields/_oclc_person.html.erb
@@ -1,0 +1,9 @@
+<%= f.input key,
+   as: :multi_value,
+   input_html: {
+      class: 'form-control',
+      data: { 'autocomplete-url' => "/authorities/search/linked_data/oclc_fast/personal_name?maximumRecords=10&q=",
+              'autocomplete' => 'linked_data',
+              'autocomplete-uri-name' => "#{key}_uri" }
+   },
+   required: f.object.required?(key) %>

--- a/config/authorities/linked_data/dbpedia.json
+++ b/config/authorities/linked_data/dbpedia.json
@@ -1,0 +1,47 @@
+{
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://guardian.slis.uiowa.edu:8080/ld4l_services/dbpedia_lookup.jsp?entity=Person&name={?term_id}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "term_id",
+          "property": "hydra:freetextQuery",
+          "required": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_id"
+    },
+    "term_id": "ID",
+    "results": {
+      "label_predicate": "http://www.w3.org/2000/01/rdf-schema#label",
+      "sameas_predicate": "http://www.w3.org/2002/07/owl#sameAs"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://guardian.slis.uiowa.edu:8080/ld4l_services/dbpedia_lookup.jsp?entity=Person&name={?query}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [{
+        "@type": "IriTemplateMapping",
+        "variable": "query",
+        "property": "hydra:freetextQuery",
+        "required": true
+      }]
+    },
+    "qa_replacement_patterns": {
+      "query": "query"
+    },
+    "results": {
+      "label_predicate": "http://www.w3.org/2000/01/rdf-schema#label",
+      "sort_predicate": "http://www.w3.org/2000/01/rdf-schema#label"
+    }
+  }
+}

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -92,7 +92,7 @@ Hyrax.config do |config|
   # Should work creation require file upload, or can a work be created first
   # and a file added at a later time?
   # The default is true.
-  # config.work_requires_files = true
+  config.work_requires_files = false
 
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
   # config.always_display_share_button = true


### PR DESCRIPTION
* add person metadata property to model, form, presenter
* add configuration for access to dbpedia linked data (via LD4L server)
* add custom renderers
  * generalized linked data renderer that shows label and uri for the subject and primary predicates from the same authority
  * add renderer to fetch additional info from dbpedia
* remove requirement to add a file